### PR TITLE
A few improvements

### DIFF
--- a/src/Controller/CompareProductController.php
+++ b/src/Controller/CompareProductController.php
@@ -34,7 +34,7 @@ class CompareProductController extends StorefrontController
     public function comparePage(Request $request, SalesChannelContext $context): Response
     {
         $page = $this->genericPageLoader->load($request, $context);
-        return $this->renderStorefront('@Storefront/storefront/page/compare.html.twig', compact('page'));
+        return $this->renderStorefront('@FroshProductCompare/storefront/page/compare.html.twig', compact('page'));
     }
 
     /**
@@ -46,7 +46,7 @@ class CompareProductController extends StorefrontController
 
         $page = $this->compareProductPageLoader->load($productIds, $request, $context);
 
-        return $this->renderStorefront('@Storefront/storefront/component/compare/content.html.twig', ['page' => $page]);
+        return $this->renderStorefront('@FroshProductCompare/storefront/component/compare/content.html.twig', ['page' => $page]);
     }
 
     /**
@@ -58,6 +58,6 @@ class CompareProductController extends StorefrontController
 
         $page = $this->compareProductPageLoader->loadPreview($productIds, $request, $context);
 
-        return $this->renderStorefront('@Storefront/storefront/component/compare/offcanvas-compare-list.html.twig', ['page' => $page]);
+        return $this->renderStorefront('@FroshProductCompare/storefront/component/compare/offcanvas-compare-list.html.twig', ['page' => $page]);
     }
 }

--- a/src/Page/CompareProductPage.php
+++ b/src/Page/CompareProductPage.php
@@ -3,11 +3,13 @@
 namespace Frosh\FroshProductCompare\Page;
 
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
+use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Storefront\Page\Page;
 
 class CompareProductPage extends Page
 {
     protected ProductListingResult $products;
+    protected PropertyGroupCollection $properties;
 
     public function getProducts(): ProductListingResult
     {
@@ -17,5 +19,15 @@ class CompareProductPage extends Page
     public function setProducts(ProductListingResult $products): void
     {
         $this->products = $products;
+    }
+
+    public function getProperties(): PropertyGroupCollection
+    {
+        return $this->properties;
+    }
+
+    public function setProperties(PropertyGroupCollection $properties): void
+    {
+        $this->properties = $properties;
     }
 }

--- a/src/Page/CompareProductPageLoader.php
+++ b/src/Page/CompareProductPageLoader.php
@@ -96,6 +96,7 @@ class CompareProductPageLoader
 
         $page = $this->genericLoader->load($request, $salesChannelContext);
 
+        /** @var CompareProductPage $page */
         $page = CompareProductPage::createFrom($page);
 
         if (empty($productIds)) {
@@ -110,6 +111,22 @@ class CompareProductPageLoader
         $result = $this->loadProductCompareData($result, $salesChannelContext);
 
         $page->setProducts($result);
+
+        $properties = new PropertyGroupCollection();
+
+        /** @var SalesChannelProductEntity $product */
+        foreach ($result as $product) {
+            foreach ($product->getSortedProperties() as $group) {
+                // we don't need more data of the PropertyGroup so we just set id and translated instead of cloning
+                $propertyGroup = new PropertyGroupEntity();
+                $propertyGroup->setId($group->getId());
+                $propertyGroup->setTranslated($group->getTranslated());
+
+                $properties->add($propertyGroup);
+            }
+        }
+
+        $page->setProperties($properties);
 
         return $page;
     }

--- a/src/Resources/views/storefront/component/compare/partial/properties.html.twig
+++ b/src/Resources/views/storefront/component/compare/partial/properties.html.twig
@@ -21,7 +21,9 @@
         {% endfor %}
         {% if not matchProperty %}
             <td class="properties-value">
-                <span>N/A</span>
+                {% block frosh_product_compare_properties_item_notset %}
+                    <span>N/A</span>
+                {% endblock %}
             </td>
         {% endif %}
     {% endfor %}

--- a/src/Resources/views/storefront/component/compare/partial/properties.html.twig
+++ b/src/Resources/views/storefront/component/compare/partial/properties.html.twig
@@ -2,7 +2,7 @@
     {% for product in products %}
         {% set matchProperty = false %}
         {% for group in product.sortedProperties %}
-            {% if group.id == property.id %}
+            {% if group.id == linePropertyId %}
                 {% set matchProperty = true %}
                 {% block frosh_product_compare_properties_cell %}
                     <td class="properties-value">

--- a/src/Resources/views/storefront/component/compare/section/overview.html.twig
+++ b/src/Resources/views/storefront/component/compare/section/overview.html.twig
@@ -26,7 +26,7 @@
         </tr>
         {% endif %}
 
-        {% if not hideRating %}
+        {% if not hideRating and config('core.listing.showReview') %}
             <tr>
                 <th>{{ "froshProductCompare.section.overview.rating"|trans|sw_sanitize }}</th>
                 {% sw_include '@Storefront/storefront/component/compare/partial/rating-cells.html.twig' %}

--- a/src/Resources/views/storefront/component/compare/section/specification.html.twig
+++ b/src/Resources/views/storefront/component/compare/section/specification.html.twig
@@ -4,13 +4,11 @@
             <th class="text-uppercase" colspan="{{ productsCount + 1 }}">{{ "froshProductCompare.section.specification.title"|trans|sw_sanitize }}</th>
         </tr>
 
-        {% set setProperties = products.first.sortedProperties %}
-
-        {% for property in setProperties %}
+        {% for property in page.properties %}
             <tr class="property">
                 <th class="capitalize">{{ property.translated.name|e }}</th>
                 {% sw_include '@Storefront/storefront/component/compare/partial/properties.html.twig' with {
-                    property: property,
+                    linePropertyId: property.id,
                 } %}
             </tr>
         {% endfor %}


### PR DESCRIPTION
- use plugin name as namespace for own templates: there are errors thrown on 6.4.5.0 for not findable template
- never show rating if review is disabled in shop
- collect all possible propertyGroups of each product for comparison: we are having some different properties. The customer should always see all properties related to compared products