### PR TITLE
Add spaces between Tags

### DIFF
--- a/src/Resources/views/storefront/component/compare/partial/description-cells.html.twig
+++ b/src/Resources/views/storefront/component/compare/partial/description-cells.html.twig
@@ -2,7 +2,7 @@
     {% for product in products %}
         {% block frosh_product_compare_description_cell %}
         <td>
-            {{ product.translated.description|raw|striptags|u.truncate(250, '…') }}
+            {{ product.translated.description|replace({'><': '> <'})raw|striptags|u.truncate(250, '…') }}
         </td>
         {% endblock %}
     {% endfor %}


### PR DESCRIPTION
Some descriptions are being displayed without spaces, e.G.: '<p>foo</p><p>bar</p>' will be displayed 'foobar'

Btw. I failed to extend this plugins templates and fix this and other issues I had. See: 
https://stackoverflow.com/questions/69902189/override-twig-template-from-plugin
I was able to do this with other plugins but not with this one.