### PR TITLE
Improve cross selling implementation

### DIFF
--- a/src/Page/CompareProductPageLoader.php
+++ b/src/Page/CompareProductPageLoader.php
@@ -112,30 +112,7 @@ class CompareProductPageLoader
 
         $page->setProducts($result);
 
-        $properties = new PropertyGroupCollection();
-
-        /** @var SalesChannelProductEntity $product */
-        foreach ($result as $product) {
-            foreach ($product->getSortedProperties() as $group) {
-                if ($properties->has($group->getId())) {
-                    continue;
-                }
-
-                // we don't need more data of the PropertyGroup so we just set id and translated instead of cloning
-                $propertyGroup = new PropertyGroupEntity();
-                $propertyGroup->setId($group->getId());
-                $propertyGroup->setTranslated($group->getTranslated());
-
-                $properties->add($propertyGroup);
-            }
-        }
-
-        $properties->sort(function ($a, $b) {
-            if ($a->getTranslation('name') === $b->getTranslation('name')) {
-                return $a->getTranslation('position') - $b->getTranslation('position');
-            }
-            return strcasecmp($a->getTranslation('name'), $b->getTranslation('name'));
-        });
+        $properties = $this->loadProperties($result);
 
         $page->setProperties($properties);
 
@@ -235,5 +212,35 @@ class CompareProductPageLoader
         }
 
         return $products;
+    }
+
+    public function loadProperties(ProductListingResult $products): PropertyGroupCollection
+    {
+        $properties = new PropertyGroupCollection();
+
+        /** @var SalesChannelProductEntity $product */
+        foreach ($products as $product) {
+            foreach ($product->getSortedProperties() as $group) {
+                if ($properties->has($group->getId())) {
+                    continue;
+                }
+
+                // we don't need more data of the PropertyGroup so we just set id and translated instead of cloning
+                $propertyGroup = new PropertyGroupEntity();
+                $propertyGroup->setId($group->getId());
+                $propertyGroup->setTranslated($group->getTranslated());
+
+                $properties->add($propertyGroup);
+            }
+        }
+
+        $properties->sort(function ($a, $b) {
+            if ($a->getTranslation('name') === $b->getTranslation('name')) {
+                return $a->getTranslation('position') - $b->getTranslation('position');
+            }
+            return strcasecmp($a->getTranslation('name'), $b->getTranslation('name'));
+        });
+
+        return $properties;
     }
 }

--- a/src/Resources/views/storefront/element/cms-element-cross-selling.html.twig
+++ b/src/Resources/views/storefront/element/cms-element-cross-selling.html.twig
@@ -1,14 +1,16 @@
-{% sw_extends '@Storefront/storefront/page/product-detail/cross-selling/tabs.html.twig' %}
+{% sw_extends '@Storefront/storefront/element/cms-element-cross-selling.html.twig' %}
 
-{% block page_product_detail_cross_selling_tabs_content_container %}
+{% block cms_element_cross_selling_tabs_content_container %}
     <div class="tab-content">
-        {% for item in crossSellings|filter(item => item.total > 0 and item.crossSelling.active == true) %}
-            {% set id = item.crossSelling.id %}
+        {% for item in element.data.crossSellings.elements|filter(item => item.total > 0 and item.crossSelling.active == true) %}
+            {% set crossSelling = item.crossSelling %}
+            {% set products = item.products %}
+            {% set id = crossSelling.id %}
             {% set crossSellingComparable = item.crossSelling.extensions.crossSellingComparable %}
             {% if crossSellingComparable and crossSellingComparable.isComparable %}
                 {% set page = {
-                    products: item.getProducts(),
-                    properties: item.crossSelling.extensions.compareProperties
+                    products: products,
+                    properties: crossSelling.extensions.compareProperties
                 } %}
                 <div class="tab-pane fade show{% if loop.first %} active{% endif %}"
                      id="cs-{{ id }}-tab-pane"
@@ -21,12 +23,12 @@
                 </div>
             {% else %}
                 <div class="tab-pane fade show{% if loop.first %} active{% endif %}"
-                     id="cs-{{ id }}-tab-pane"
+                     id="cross-selling-tab-{{ id }}-pane"
                      role="tabpanel"
-                     aria-labelledby="cs-{{ id }}-tab">
+                     aria-labelledby="cross-selling-tab-{{ id }}">
                     {% set config = {
                         'title': {
-                            'value': item.crossSelling.name ?: item.crossSelling.translated.name
+                            'value': crossSelling.name ?: crossSelling.translated.name
                         },
                         'border': {
                             'value': false
@@ -35,36 +37,37 @@
                             'value': false
                         },
                         'products': {
-                            'value': item.getProducts()
+                            'value': products
                         },
                         'boxLayout': {
-                            'value': 'standard'
+                            'value': sliderConfig.boxLayout.value
                         },
                         'elMinWidth': {
-                            'value': '300px'
+                            'value': sliderConfig.elMinWidth.value
                         },
                         'navigation': {
                             'value': true
                         },
                         'displayMode': {
-                            'value': 'minimal'
+                            'value': sliderConfig.displayMode.value
                         },
                         'verticalAlign': {
-                            'value': 'top'
-                        },
-                    } %}
-
-                    {% sw_include "@Storefront/storefront/element/cms-element-product-slider.html.twig" with {
-                        sliderConfig: config,
-                        element: {
-                            'data': {
-                                'products': {
-                                    elements: item.getProducts()
-                                }
-                            },
-                            type: 'product-slider'
+                            'value': center
                         }
                     } %}
+
+                    {% block cms_element_cross_selling_tabs_content_container_slider %}
+                        {% sw_include "@Storefront/storefront/element/cms-element-product-slider.html.twig" with {
+                            sliderConfig: config,
+                            element: {
+                                'data': {
+                                    'products': products
+                                },
+                                type: 'product-slider'
+                            }
+                        } %}
+                    {% endblock %}
+
                 </div>
             {% endif %}
         {% endfor %}

--- a/src/Subscriber/FroshCrossSellingProductListingSubscriber.php
+++ b/src/Subscriber/FroshCrossSellingProductListingSubscriber.php
@@ -119,6 +119,10 @@ class FroshCrossSellingProductListingSubscriber implements EventSubscriberInterf
             $productWithComparableData = $this->compareProductPageLoader->loadProductCompareData($products, $salesChannelContext);
 
             $crossSellingElement->setProducts(new ProductCollection($productWithComparableData));
+
+            $properties = $this->compareProductPageLoader->loadProperties($products);
+
+            $crossSelling->addExtension('compareProperties', $properties);
         }
     }
 


### PR DESCRIPTION
Cross selling implementation is incomplete at the moment with property comparison missing.

This PR includes:

- product detail cross selling tabs template updated to current SW template
- compare property loading extracted to public function
- compare properties added to cross sellings in loaded subscriber
- support for cms cross selling element (used in custom product pages)