### PR TITLE
Some descriptions are being displayed without spaces, e.G.: '<p>foo</…

### DIFF
--- a/src/Resources/views/storefront/component/compare/partial/description-cells.html.twig
+++ b/src/Resources/views/storefront/component/compare/partial/description-cells.html.twig
@@ -2,7 +2,7 @@
     {% for product in products %}
         {% block frosh_product_compare_description_cell %}
         <td>
-            {{ product.translated.description|raw|striptags|u.truncate(250, '…') }}
+            {{ product.translated.description|replace({'><': '> <'})raw|striptags|u.truncate(250, '…') }}
         </td>
         {% endblock %}
     {% endfor %}


### PR DESCRIPTION
…p><p>bar</p>' will be displayed 'foobar'

[Originally by iMiMWeis]

See #35 #37 