### PR TITLE
Small fixes

### DIFF
--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -3,7 +3,7 @@
 {% block base_body_inner %}
     {{ parent() }}
 
-    {% block frosh_product_compare_float_button %}
+    {% block frosh_product_compare_float_button_container %}
         {% sw_include '@Storefront/storefront/component/compare/compare-float.html.twig' %}
     {% endblock %}
 {% endblock %}

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -1,7 +1,8 @@
 {% sw_extends '@Storefront/storefront/base.html.twig' %}
 
-{% block base_body %}
+{% block base_body_inner %}
     {{ parent() }}
+
     {% block frosh_product_compare_float_button %}
         {% sw_include '@Storefront/storefront/component/compare/compare-float.html.twig' %}
     {% endblock %}

--- a/src/Resources/views/storefront/component/compare/content.html.twig
+++ b/src/Resources/views/storefront/component/compare/content.html.twig
@@ -11,7 +11,7 @@
         {% set hideSpecs = 'specs' in hideAttributes %}
 
         {% set productsCount = products.count %}
-        {% set isAjaxContent = app.request.attributes.get('_route') == 'frontend.compare.content' %}
+        {% set isAjaxContent = activeRoute == 'frontend.compare.content' %}
         {% if productsCount is same as(0) %}
             {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
                 type: "info",

--- a/src/Resources/views/storefront/component/compare/partial/description-cells.html.twig
+++ b/src/Resources/views/storefront/component/compare/partial/description-cells.html.twig
@@ -2,7 +2,7 @@
     {% for product in products %}
         {% block frosh_product_compare_description_cell %}
         <td>
-            {{ product.translated.description|replace({'><': '> <'})raw|striptags|u.truncate(250, '…') }}
+            {{ product.translated.description|replace({'><': '> <'})|raw|striptags|u.truncate(250, '…') }}
         </td>
         {% endblock %}
     {% endfor %}

--- a/src/Resources/views/storefront/component/product/card/action.html.twig
+++ b/src/Resources/views/storefront/component/product/card/action.html.twig
@@ -3,7 +3,7 @@
 {% block component_product_box_action_buy %}
     {{ parent() }}
 
-    {% if app.request.attributes.get('_route') != 'frontend.compare.content' %}
+    {% if activeRoute != 'frontend.compare.content' %}
         {% block component_product_box_action_add_to_compare_button %}
             {% sw_include '@Storefront/storefront/component/product/card/compare-button.html.twig' %}
         {% endblock %}
@@ -13,7 +13,7 @@
 {% block component_product_box_action_detail %}
     {{ parent() }}
 
-    {% if app.request.attributes.get('_route') != 'frontend.compare.content' %}
+    {% if activeRoute != 'frontend.compare.content' %}
         {% block component_product_box_action_detail_add_to_compare_button %}
             {% sw_include '@Storefront/storefront/component/product/card/compare-button.html.twig' %}
         {% endblock %}


### PR DESCRIPTION
- put the button inside the body for valid HTML
- the name for block frosh_product_compare_float_button is also used inside
- use the accessible variable `activeRoute` instead of `app.request.attributes.get('_route')`
- fix Exception `Can not render @FroshProductCompare/storefront/component/compare/content.html.twig view: Unexpected token "name" of value "raw" ("end of print statement" expected).` introduced by https://github.com/FriendsOfShopware/FroshProductCompare/pull/47