### PR TITLE
feat: add support for shopware 6.5 and 6.6 simultaneously

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "frosh/product-compare",
     "description": "A Simple Product Compare plugin for Shopware 6",
-    "version": "3.0.0",
+    "version": "2.0.1",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [
@@ -15,8 +15,8 @@
         }
     ],
     "require": {
-        "shopware/core": "^6.6",
-        "shopware/storefront": "^6.6"
+        "shopware/core": "~6.5.0||~6.6.0",
+        "shopware/storefront": "~6.5.0||~6.6.0"
     },
     "extra": {
         "shopware-plugin-class": "Frosh\\FroshProductCompare\\FroshProductCompare",

--- a/src/Controller/CompareProductController.php
+++ b/src/Controller/CompareProductController.php
@@ -10,7 +10,7 @@ use Shopware\Storefront\Controller\StorefrontController;
 use Shopware\Storefront\Page\GenericPageLoaderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Annotation\Route;
 
 #[Route(defaults: ['_routeScope' => ['storefront']])]
 class CompareProductController extends StorefrontController


### PR DESCRIPTION
- the version constraint is not specific enough
- we can support shopware 6.5 and 6.6 simultaneously, see https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/Routing/Annotation/Route.php#L14
