### PR TITLE
Verify products

### DIFF
--- a/src/Controller/CompareProductController.php
+++ b/src/Controller/CompareProductController.php
@@ -60,8 +60,8 @@ class CompareProductController extends StorefrontController
     public function verifyProducts(Request $request, SalesChannelContext $context): Response
     {
         $productIds = $request->get('productIds', []);
-        $productIds = $this->compareProductPageLoader->verifyProducts($productIds, $context);
+        $validProductIds = $this->compareProductPageLoader->verifyProducts($productIds, $context);
 
-        return new JsonResponse($productIds, 200);
+        return new JsonResponse($validProductIds, 200);
     }
 }

--- a/src/Controller/CompareProductController.php
+++ b/src/Controller/CompareProductController.php
@@ -6,6 +6,7 @@ use Frosh\FroshProductCompare\Page\CompareProductPageLoader;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\StorefrontController;
 use Shopware\Storefront\Page\GenericPageLoaderInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -53,5 +54,14 @@ class CompareProductController extends StorefrontController
         $page = $this->compareProductPageLoader->loadPreview($productIds, $request, $context);
 
         return $this->renderStorefront('@FroshProductCompare/storefront/component/compare/offcanvas-compare-list.html.twig', ['page' => $page]);
+    }
+
+    #[Route(path: '/compare/verify-products', name: 'frontend.compare.verify-products', options: ['seo' => false], defaults: ['_httpCache' => false, 'XmlHttpRequest' => true], methods: ['POST'])]
+    public function verifyProducts(Request $request, SalesChannelContext $context): Response
+    {
+        $productIds = $request->get('productIds', []);
+        $productIds = $this->compareProductPageLoader->verifyProducts($productIds, $context);
+
+        return new JsonResponse($productIds, 200);
     }
 }

--- a/src/Page/CompareProductPageLoader.php
+++ b/src/Page/CompareProductPageLoader.php
@@ -343,7 +343,10 @@ class CompareProductPageLoader
         }
 
         $products = $this->productGateway->get($productIds, $salesChannelContext);
+        if(!$products->count()) {
+            return [];
+        }
 
-        return array_values(map($products, fn($product) => $product->getId()));
+        return array_values($products->map(fn($product) => $product->getId()));
     }
 }

--- a/src/Page/CompareProductPageLoader.php
+++ b/src/Page/CompareProductPageLoader.php
@@ -326,4 +326,24 @@ class CompareProductPageLoader
 
         return $availableCustomFieldNames;
     }
+
+    /**
+     * @param array $productIds
+     * @param SalesChannelContext $salesChannelContext
+     * @return array<string>
+     */
+    public function verifyProducts(array $productIds, SalesChannelContext $salesChannelContext): array
+    {
+        $productIds = array_filter(\array_slice($productIds, 0, self::MAX_COMPARE_PRODUCT_ITEMS), function ($id) {
+            return Uuid::isValid($id);
+        });
+
+        if (empty($productIds)) {
+            return [];
+        }
+
+        $products = $this->productGateway->get($productIds, $salesChannelContext);
+
+        return array_values(map($products, fn($product) => $product->getId()));
+    }
 }

--- a/src/Page/CompareProductPageLoader.php
+++ b/src/Page/CompareProductPageLoader.php
@@ -151,10 +151,12 @@ class CompareProductPageLoader
                     continue;
                 }
 
-                // we don't need more data of the PropertyGroup, so we just set id and translated instead of cloning
+                // we don't need more data of the PropertyGroup, so we just set id, translated and visibleOnProductDetailPage instead of cloning
                 $propertyGroup = new PropertyGroupEntity();
                 $propertyGroup->setId($group->getId());
                 $propertyGroup->setTranslated($group->getTranslated());
+                $propertyGroup->setVisibleOnProductDetailPage($group->getVisibleOnProductDetailPage());
+
 
                 $properties->add($propertyGroup);
             }

--- a/src/Resources/app/storefront/src/helper/compare-local-storage.helper.js
+++ b/src/Resources/app/storefront/src/helper/compare-local-storage.helper.js
@@ -1,4 +1,5 @@
 import Storage from 'src/helper/storage/storage.helper';
+import HttpClient from 'src/service/http-client.service';
 
 class CompareLocalStorageHelper {
     static key = 'compare-widget-added-products';

--- a/src/Resources/app/storefront/src/helper/compare-local-storage.helper.js
+++ b/src/Resources/app/storefront/src/helper/compare-local-storage.helper.js
@@ -17,14 +17,14 @@ class CompareLocalStorageHelper {
                 const failed = !response || response.status >= 400
                     || !responseText;
 
-                // test99
-                // if (failed) {
-                //     this.persist([]);
-                //     fulfill();
-                // }
-                //
-                // const res = JSON.parse(responseText);
-                //this.persist(["03d407427a42499dc0dfb6fb0384caf7","045aa4a5d4e3cdfd971c07ec5cd6cb3a","05a4d8f5be03b47773f5ba8bb6742a37"]);
+                if (failed) {
+                    this.persist([]);
+                    fulfill();
+                    return;
+                }
+
+                const productIds = JSON.parse(responseText);
+                this.persist(productIds);
                 fulfill();
             });
         });

--- a/src/Resources/app/storefront/src/helper/compare-local-storage.helper.js
+++ b/src/Resources/app/storefront/src/helper/compare-local-storage.helper.js
@@ -5,6 +5,30 @@ class CompareLocalStorageHelper {
 
     static maximumCompareProducts = 4;
 
+    static verifyAddedProductsList() {
+        const products = this.getAddedProductsList();
+        const jsonProducts = JSON.stringify({
+            productIds: products
+        });
+
+        return new Promise(fulfill => {
+            new HttpClient().post("/compare/verify-products", jsonProducts, (responseText, response) => {
+                const failed = !response || response.status >= 400
+                    || !responseText;
+
+                // test99
+                // if (failed) {
+                //     this.persist([]);
+                //     fulfill();
+                // }
+                //
+                // const res = JSON.parse(responseText);
+                //this.persist(["03d407427a42499dc0dfb6fb0384caf7","045aa4a5d4e3cdfd971c07ec5cd6cb3a","05a4d8f5be03b47773f5ba8bb6742a37"]);
+                fulfill();
+            });
+        });
+    }
+
     static getAddedProductsList() {
         let products = Storage.getItem(this.key);
 

--- a/src/Resources/app/storefront/src/plugin/compare-float.plugin.js
+++ b/src/Resources/app/storefront/src/plugin/compare-float.plugin.js
@@ -16,9 +16,9 @@ export default class CompareFloatPlugin extends Plugin {
 
         CompareLocalStorageHelper.verifyAddedProductsList().then(() => {
             this._updateButtonCounter(CompareLocalStorageHelper.getAddedProductsList());
+            this._addBodyPadding();
+            this._registerEvents();
         });
-        this._addBodyPadding();
-        this._registerEvents();
     }
 
     _updateButtonCounter(products) {

--- a/src/Resources/app/storefront/src/plugin/compare-float.plugin.js
+++ b/src/Resources/app/storefront/src/plugin/compare-float.plugin.js
@@ -14,7 +14,9 @@ export default class CompareFloatPlugin extends Plugin {
         this._defaultPadding = window.getComputedStyle(this._button).getPropertyValue('bottom');
         this._badge = this._button.querySelector('.badge');
 
-        this._updateButtonCounter(CompareLocalStorageHelper.getAddedProductsList());
+        CompareLocalStorageHelper.verifyAddedProductsList().then(() => {
+            this._updateButtonCounter(CompareLocalStorageHelper.getAddedProductsList());
+        });
         this._addBodyPadding();
         this._registerEvents();
     }


### PR DESCRIPTION
- Add property visibility to comparison
- Verify product ids that are saved to locally and presented on the compare button. If a product is not available anymore, it should not be considered for comparison and therefore the number of products should be displayed correctly.