### PR TITLE
Change float button event on touch devices

### DIFF
--- a/src/Resources/app/storefront/src/plugin/compare-float.plugin.js
+++ b/src/Resources/app/storefront/src/plugin/compare-float.plugin.js
@@ -34,7 +34,7 @@ export default class CompareFloatPlugin extends window.PluginBaseClass {
      * @private
      */
     _registerEvents() {
-        const submitEvent = ('ontouchstart' in document.documentElement) ? 'touchstart' : 'click';
+        const submitEvent = 'click';
 
         if (this._button) {
             this._button.addEventListener(submitEvent, () => {


### PR DESCRIPTION
On android devices clicking on the float compare button only works when holding the button for a longer time, not on a simple click. I think this behaviour is not intended. Changing the event to "click" for all devices fixes that.