### PR TITLE
Change loading product reviews first page to loading total count

### DIFF
--- a/src/Resources/views/storefront/component/compare/partial/rating-cells.html.twig
+++ b/src/Resources/views/storefront/component/compare/partial/rating-cells.html.twig
@@ -10,7 +10,7 @@
                    target="_blank"
                    href="{{ seoUrl('frontend.detail.page', {'productId': product.id}) }}#review-tab-pane"
                    aria-controls="review-tab-pane">
-                    {{ "froshProductCompare.section.content.reviewLinkText"|trans({'%count%': product.productReviews.count})|sw_sanitize }}
+                    {{ "froshProductCompare.section.content.reviewLinkText"|trans({'%count%': product.extensions.productReviews.reviewTotal})|sw_sanitize }}
                 </a>
             </td>
         {% endblock %}


### PR DESCRIPTION
With Shopware 6.6 only the first page of reviews is loaded with the ProductReviewLoader. Using the count of entities will thus be inaccurate, since everything over 10 is capped. I would propose to not set the product reviews but to just add an extension with the total count that is then displayed on the compare page.