### PR TITLE
Fix compare float button behaviour on mobile Android

### DIFF
--- a/src/Resources/app/storefront/src/plugin/compare-float.plugin.js
+++ b/src/Resources/app/storefront/src/plugin/compare-float.plugin.js
@@ -37,9 +37,10 @@ export default class CompareFloatPlugin extends window.PluginBaseClass {
         const submitEvent = ('ontouchstart' in document.documentElement) ? 'touchstart' : 'click';
 
         if (this._button) {
-            this._button.addEventListener(submitEvent, () => {
-                this._openOffcanvas();
-                this.$emitter.publish('onClickCompareFloatButton');
+            this._button.addEventListener(submitEvent, (event) => {
+              event.preventDefault();
+              this._openOffcanvas();
+              this.$emitter.publish('onClickCompareFloatButton');
             });
         }
 


### PR DESCRIPTION
On android devices clicking on the float compare button only works when holding the button for a longer time, not on a simple click. Adding "event.preventDefault()" fixes this.