### PR TITLE
[FIX] made compare button on mobile react on tap

### DIFF
--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,3 +1,6 @@
+# 3.0.2
+- Fix: made compare button on mobile react on tap
+
 # 3.0.1
 - Changed snippet of title in buttons of product compare
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "frosh/product-compare",
     "description": "A Simple Product Compare plugin for Shopware 6",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/src/Resources/app/storefront/src/plugin/compare-float.plugin.js
+++ b/src/Resources/app/storefront/src/plugin/compare-float.plugin.js
@@ -37,7 +37,8 @@ export default class CompareFloatPlugin extends window.PluginBaseClass {
         const submitEvent = ('ontouchstart' in document.documentElement) ? 'touchstart' : 'click';
 
         if (this._button) {
-            this._button.addEventListener(submitEvent, () => {
+            this._button.addEventListener(submitEvent, (event) => {
+                event.preventDefault();
                 this._openOffcanvas();
                 this.$emitter.publish('onClickCompareFloatButton');
             });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the responsiveness of the compare button on mobile devices, ensuring it reacts correctly to tap events.

- **Documentation**
  - Updated the changelog to include details for version 3.0.2.

- **Chores**
  - Bumped the version number to 3.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->