### PR TITLE
Responsive product comparison table

### DIFF
--- a/src/Resources/app/storefront/src/scss/compare.scss
+++ b/src/Resources/app/storefront/src/scss/compare.scss
@@ -12,7 +12,7 @@
     -ms-overflow-style: -ms-autohiding-scrollbar;
 
     table {
-        width: unset!important;
+        width: 100%!important;
         min-width: 41rem;
         table-layout: fixed;
 
@@ -38,11 +38,6 @@
             border-top-width: 1px;
         }
 
-        &.table-bordered th, &.table-bordered td {
-            padding: $table-cell-padding;
-            border-top: $table-border-width solid $table-border-color;
-        }
-
         .is-feature-item {
             .comparison-item-title {
                 color: $success;
@@ -50,10 +45,37 @@
         }
     }
 
-    .table-bordered thead {
-        td {
-            border-bottom-width: 1px;
-            background-color: $white;
+    .table-bordered {
+        border-collapse: separate;
+        border-spacing: 0;
+
+        thead {
+            td {
+                border-bottom-width: 1px;
+                background-color: $white;
+            }
+        }
+
+        th, td {
+            padding: $table-cell-padding;
+            border-top: $table-border-width solid $table-border-color;
+
+            &:first-child {
+                position: sticky;
+                left: 0;
+                z-index: 100;
+                width: 150px;
+
+                &:before {
+                    content: "";
+                    position: absolute;
+                    height: 100%;
+                    width: 4px;
+                    top: 0;
+                    left: -3px;
+                    background: white;
+                }
+            }
         }
     }
 

--- a/src/Resources/views/storefront/component/compare/section/overview.html.twig
+++ b/src/Resources/views/storefront/component/compare/section/overview.html.twig
@@ -1,9 +1,11 @@
 {% block frosh_product_compare_overview_section %}
     <tbody id="overview" data-filter="target" class="accordion-item">
         <tr>
-            <th class="text-uppercase" colspan="{{ productsCount + 1 }}">
+            <th class="text-uppercase">
                 <a href="javascript:void(0);" target="_blank" class="accordion-button text-black p-0 bg-transparent text-decoration-none box-shadow-no"  type="button" data-bs-toggle="collapse" data-bs-target=".collapseOverview" aria-expanded="true" aria-controls="collapseOverview">{{ "froshProductCompare.section.overview.title"|trans|sw_sanitize }}</a>
             </th>
+
+            <th colspan="{{ productsCount }}"></th>
         </tr>
         {% block frosh_product_compare_overview_section_manufacturer %}
             {% if not hideManufacturer %}

--- a/src/Resources/views/storefront/component/compare/section/specification.html.twig
+++ b/src/Resources/views/storefront/component/compare/section/specification.html.twig
@@ -1,11 +1,13 @@
 {% block frosh_product_compare_specification_section %}
     <tbody id="specification">
         <tr>
-            <th class="text-uppercase" colspan="{{ productsCount + 1 }}">
+            <th class="text-uppercase">
                 <a href="javascript:void(0);" target="_blank" class="accordion-button text-black p-0 bg-transparent text-decoration-none box-shadow-no"  type="button" data-bs-toggle="collapse" data-bs-target=".collapseSpecifications" aria-expanded="true" aria-controls="collapseSpecifications">
                     {{ "froshProductCompare.section.specification.title"|trans|sw_sanitize }}
                 </a>
             </th>
+
+            <th colspan="{{ productsCount }}"></th>
         </tr>
 
         {% for property in page.properties %}
@@ -27,9 +29,8 @@
                     {% sw_include '@Storefront/storefront/component/compare/partial/custom-field.html.twig' with {
                         customField: customField,
                     } %}
+                </tr>
             {% endif %}
-            </tr>
         {% endfor %}
-
     </tbody>
 {% endblock %}


### PR DESCRIPTION
The current state of the plugin has no responsive solution for the comparison table.
This PR makes the first column fixed, if there's not enough space and let the user scroll horizontally through the products.