### PR TITLE
fix: Emit event on clearing local storage for comparison

### DIFF
--- a/src/Resources/app/storefront/src/helper/compare-local-storage.helper.ts
+++ b/src/Resources/app/storefront/src/helper/compare-local-storage.helper.ts
@@ -65,6 +65,8 @@ class CompareLocalStorageHelper {
 
     static clear() {
         window.localStorage.removeItem(this.key);
+
+        document.$emitter.publish('changedProductCompare', { products: [] });
     }
 
     static _checkCompareProductStorage(products) {


### PR DESCRIPTION
Problem:
Product counts in badges don't update when using "Clear all" button in compare page.

Fix:
Publish 'changedProductCompare' event with empty products array when clearing local storage.