### PR TITLE
feat: add compare button configuration and closeout product handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ coverage/
 vendor/
 var/
 phpstan.neon
-src/Resources/public/administration/frosh-product-compare.*.hot-update.js
+src/Resources/public/
 frosh-product-compare.js
 frosh-product-compare.css
 node_modules

--- a/src/Page/CompareProductPageLoader.php
+++ b/src/Page/CompareProductPageLoader.php
@@ -57,11 +57,10 @@ class CompareProductPageLoader
             return $page;
         }
 
-        $criteria = new Criteria();
-        $criteria->setIds($productIds)->setLimit(self::MAX_COMPARE_PRODUCT_ITEMS);
-        $criteria->addAssociation('featureSet');
-
-        $products = $this->productGateway->get($productIds, $salesChannelContext);
+        $products = $this->filterCloseoutProducts(
+            $this->productGateway->get($productIds, $salesChannelContext),
+            $salesChannelContext
+        );
 
         $result = ProductListingResult::createFrom($products);
 
@@ -90,7 +89,10 @@ class CompareProductPageLoader
             return $page;
         }
 
-        $products = $this->productGateway->get($productIds, $salesChannelContext);
+        $products = $this->filterCloseoutProducts(
+            $this->productGateway->get($productIds, $salesChannelContext),
+            $salesChannelContext
+        );
 
         $result = ProductListingResult::createFrom($products);
 
@@ -313,5 +315,14 @@ class CompareProductPageLoader
         }
 
         return $availableCustomFieldNames;
+    }
+
+    private function filterCloseoutProducts(ProductCollection $products, SalesChannelContext $context): ProductCollection
+    {
+        if (!$this->systemConfigService->getBool('core.listing.hideCloseoutProductsWhenOutOfStock', $context->getSalesChannelId())) {
+            return $products;
+        }
+
+        return $products->filter(fn (SalesChannelProductEntity $product) => !$product->getIsCloseout() || $product->getAvailable());
     }
 }

--- a/src/Resources/app/storefront/src/helper/compare-local-storage.helper.ts
+++ b/src/Resources/app/storefront/src/helper/compare-local-storage.helper.ts
@@ -63,6 +63,18 @@ class CompareLocalStorageHelper {
         document.$emitter.publish('changedProductCompare', { products });
     }
 
+    static sync(validProductIds) {
+        const stored = this.getAddedProductsList();
+        const cleaned = stored.filter((id) => validProductIds.includes(id));
+        const removedCount = stored.length - cleaned.length;
+
+        if (removedCount > 0) {
+            this.persist(cleaned);
+        }
+
+        return removedCount;
+    }
+
     static clear() {
         window.localStorage.removeItem(this.key);
 

--- a/src/Resources/app/storefront/src/plugin/add-to-compare-button.plugin.js
+++ b/src/Resources/app/storefront/src/plugin/add-to-compare-button.plugin.js
@@ -3,6 +3,8 @@ import CompareLocalStorageHelper from '../helper/compare-local-storage.helper';
 export default class AddToCompareButtonPlugin extends window.PluginBaseClass {
     static options = {
         isAddedToCompareClass: 'is-added-to-compare',
+        defaultButtonClass: 'btn-primary',
+        selectedButtonClass: 'btn-secondary',
     };
 
     init() {
@@ -19,11 +21,12 @@ export default class AddToCompareButtonPlugin extends window.PluginBaseClass {
     }
 
     _checkAddedProduct() {
-        const { productId, addedText, isAddedToCompareClass } = this.options;
+        const { productId, addedText, isAddedToCompareClass, defaultButtonClass, selectedButtonClass } = this.options;
 
         if (this._isAddedProduct(productId) && addedText) {
             this._toggleText(this.el, addedText);
-            this.el.classList.add(isAddedToCompareClass);
+            this.el.classList.remove(defaultButtonClass);
+            this.el.classList.add(isAddedToCompareClass, selectedButtonClass);
         }
     }
 
@@ -67,7 +70,7 @@ export default class AddToCompareButtonPlugin extends window.PluginBaseClass {
     }
 
     _handleBeforeRemove() {
-        const { defaultText, isAddedToCompareClass, productId } = this.options;
+        const { defaultText, isAddedToCompareClass, defaultButtonClass, selectedButtonClass, productId } = this.options;
 
         const product = { productId };
 
@@ -78,7 +81,8 @@ export default class AddToCompareButtonPlugin extends window.PluginBaseClass {
                 'none';
         } else {
             this._toggleText(this.el, defaultText);
-            this.el.classList.remove(isAddedToCompareClass);
+            this.el.classList.remove(isAddedToCompareClass, selectedButtonClass);
+            this.el.classList.add(defaultButtonClass);
         }
 
         document.$emitter.publish(this.REMOVE_COMPARE_PRODUCT_EVENT, {
@@ -87,23 +91,25 @@ export default class AddToCompareButtonPlugin extends window.PluginBaseClass {
     }
 
     _handleBeforeAdd() {
-        const { addedText, isAddedToCompareClass } = this.options;
+        const { addedText, isAddedToCompareClass, defaultButtonClass, selectedButtonClass } = this.options;
 
         this._toggleText(this.el, addedText);
-        this.el.classList.add(isAddedToCompareClass);
+        this.el.classList.remove(defaultButtonClass);
+        this.el.classList.add(isAddedToCompareClass, selectedButtonClass);
     }
 
     _registerEvents() {
         this._registerCompareButtonSelection();
 
-        const { productId, isAddedToCompareClass, defaultText } = this.options;
+        const { productId, isAddedToCompareClass, defaultButtonClass, selectedButtonClass, defaultText } = this.options;
 
         document.$emitter.subscribe(
             this.REMOVE_COMPARE_PRODUCT_EVENT,
             (event) => {
                 if (event.detail.product.productId === productId) {
                     this._toggleText(this.el, defaultText);
-                    this.el.classList.remove(isAddedToCompareClass);
+                    this.el.classList.remove(isAddedToCompareClass, selectedButtonClass);
+                    this.el.classList.add(defaultButtonClass);
                 }
             }
         );

--- a/src/Resources/app/storefront/src/plugin/compare-float.plugin.js
+++ b/src/Resources/app/storefront/src/plugin/compare-float.plugin.js
@@ -90,8 +90,49 @@ export default class CompareFloatPlugin extends window.PluginBaseClass {
             window.router['frontend.compare.offcanvas'],
             formData,
             (response) => {
+                const parser = new DOMParser();
+                const doc = parser.parseFromString(response, 'text/html');
+                const container = doc.querySelector('[data-valid-product-ids]');
+                let removedCount = 0;
+
+                if (container) {
+                    const validIds = Object.values(JSON.parse(container.dataset.validProductIds));
+                    removedCount = CompareLocalStorageHelper.sync(validIds);
+                }
+
+                if (removedCount > 0) {
+                    this._showRemovedProductsAlert(removedCount);
+                }
+
                 this.$emitter.publish('insertStoredContent', { response });
             }
         );
+    }
+
+    _showRemovedProductsAlert(removedCount) {
+        const offcanvasContent = document.querySelector('.offcanvas-cart');
+        if (!offcanvasContent) {
+            return;
+        }
+
+        const header = offcanvasContent.querySelector('.offcanvas-cart-header');
+        if (!header) {
+            return;
+        }
+
+        const alert = document.createElement('div');
+        alert.setAttribute('role', 'alert');
+        alert.setAttribute('aria-live', 'polite');
+        alert.className = 'alert alert-info d-flex align-items-center alert-dismissible fade show';
+        alert.innerHTML = `
+            <div class="alert-content-container">
+                ${this.options.productsRemovedText.replace('%count%', removedCount)}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true"></span>
+                </button>
+            </div>
+        `;
+
+        header.insertAdjacentElement('afterend', alert);
     }
 }

--- a/src/Resources/app/storefront/src/plugin/compare-widget.plugin.js
+++ b/src/Resources/app/storefront/src/plugin/compare-widget.plugin.js
@@ -68,6 +68,7 @@ export default class CompareWidgetPlugin extends window.PluginBaseClass {
                 ElementLoadingIndicatorUtil.remove(this.el);
 
                 this.renderCompareProducts(text);
+                this._syncLocalStorage();
 
                 this.$emitter.publish('insertStoredContent', {
                     response: text,
@@ -78,6 +79,35 @@ export default class CompareWidgetPlugin extends window.PluginBaseClass {
     renderCompareProducts(html) {
         this.el.querySelector('.compare-product-content').innerHTML = html;
         window.PluginManager.initializePlugins();
+    }
+
+    _syncLocalStorage() {
+        const container = this.el.querySelector('[data-valid-product-ids]');
+        if (container) {
+            const validIds = Object.values(JSON.parse(container.dataset.validProductIds));
+            const removedCount = CompareLocalStorageHelper.sync(validIds);
+
+            if (removedCount > 0) {
+                this._showRemovedProductsAlert(removedCount, container);
+            }
+        }
+    }
+
+    _showRemovedProductsAlert(removedCount, container) {
+        const alert = document.createElement('div');
+        alert.setAttribute('role', 'alert');
+        alert.setAttribute('aria-live', 'polite');
+        alert.className = 'alert alert-info d-flex align-items-center alert-dismissible fade show';
+        alert.innerHTML = `
+            <div class="alert-content-container">
+                ${this.options.productsRemovedText.replace('%count%', removedCount)}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true"></span>
+                </button>
+            </div>
+        `;
+
+        container.insertAdjacentElement('beforebegin', alert);
     }
 
     _registerEvents() {

--- a/src/Resources/app/storefront/src/scss/base.scss
+++ b/src/Resources/app/storefront/src/scss/base.scss
@@ -4,14 +4,6 @@
 
 .compare-button {
     margin-top: 10px;
-    .btn-compare {
-        @extend .btn-lg;
-        @include button-variant($buy-btn-bg, $buy-btn-bg);
-
-        &.is-added-to-compare {
-            @include button-variant($disabled-btn-bg, $disabled-btn-bg);
-        }
-    }
 }
 
 .compare-float-button {

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -19,11 +19,92 @@
             <defaultValue>false</defaultValue>
         </input-field>
 
+        <input-field type="single-select">
+            <name>compareButtonStyle</name>
+            <label>Button style for "Add to compare"</label>
+            <label lang="de-DE">Button-Stil für "Zum Vergleich hinzufügen"</label>
+            <helpText>Bootstrap variant for compare buttons on product cards (listing, detail page).</helpText>
+            <helpText lang="de-DE">Bootstrap-Variante für Vergleichs-Buttons auf Produktkarten (Listing, Detailseite).</helpText>
+            <defaultValue>primary</defaultValue>
+            <options>
+                <option>
+                    <id>primary</id>
+                    <name>Primary</name>
+                </option>
+                <option>
+                    <id>secondary</id>
+                    <name>Secondary</name>
+                </option>
+                <option>
+                    <id>outline-primary</id>
+                    <name>Outline Primary</name>
+                </option>
+                <option>
+                    <id>outline-secondary</id>
+                    <name>Outline Secondary</name>
+                </option>
+            </options>
+        </input-field>
+
+        <input-field type="single-select">
+            <name>compareButtonSelectedStyle</name>
+            <label>Button style when product is selected</label>
+            <label lang="de-DE">Button-Stil wenn Produkt ausgewählt</label>
+            <helpText>Bootstrap variant for the compare button when the product has been added to the comparison.</helpText>
+            <helpText lang="de-DE">Bootstrap-Variante für den Vergleichs-Button, wenn das Produkt zum Vergleich hinzugefügt wurde.</helpText>
+            <defaultValue>secondary</defaultValue>
+            <options>
+                <option>
+                    <id>primary</id>
+                    <name>Primary</name>
+                </option>
+                <option>
+                    <id>secondary</id>
+                    <name>Secondary</name>
+                </option>
+                <option>
+                    <id>outline-primary</id>
+                    <name>Outline Primary</name>
+                </option>
+                <option>
+                    <id>outline-secondary</id>
+                    <name>Outline Secondary</name>
+                </option>
+            </options>
+        </input-field>
+
         <input-field type="bool">
             <name>showInHeader</name>
             <label>Show comparison in header</label>
             <label lang="de-DE">Zeige Vergleichen auch im Header</label>
             <defaultValue>false</defaultValue>
+        </input-field>
+
+        <input-field type="single-select">
+            <name>floatingButtonStyle</name>
+            <label>Button style for floating compare button</label>
+            <label lang="de-DE">Button-Stil für den Floating-Vergleichs-Button</label>
+            <helpText>Bootstrap variant for the floating compare button in the header area.</helpText>
+            <helpText lang="de-DE">Bootstrap-Variante für den schwebenden Vergleichs-Button im Header-Bereich.</helpText>
+            <defaultValue>primary</defaultValue>
+            <options>
+                <option>
+                    <id>primary</id>
+                    <name>Primary</name>
+                </option>
+                <option>
+                    <id>secondary</id>
+                    <name>Secondary</name>
+                </option>
+                <option>
+                    <id>outline-primary</id>
+                    <name>Outline Primary</name>
+                </option>
+                <option>
+                    <id>outline-secondary</id>
+                    <name>Outline Secondary</name>
+                </option>
+            </options>
         </input-field>
 
         <input-field type="multi-select">

--- a/src/Resources/snippet/froshProductCompare.de-DE.json
+++ b/src/Resources/snippet/froshProductCompare.de-DE.json
@@ -10,7 +10,8 @@
             "empty": "Bisher wurden keine Produkte zum Vergleich hinzugefügt.",
             "headline": "Produkte vergleichen",
             "maximumCompareProducts": "Die maximale Anzahl von Vergleichsprodukten beträgt 4",
-            "removeFromCompare": "Aus dem Vergleich entfernen"
+            "removeFromCompare": "Aus dem Vergleich entfernen",
+            "productsRemoved": "%count% nicht mehr verfügbare(s) Produkt(e) wurde(n) aus dem Vergleich entfernt."
         },
         "offcanvas": {
             "compareNow": "Jetzt vergleichen",

--- a/src/Resources/snippet/froshProductCompare.en-GB.json
+++ b/src/Resources/snippet/froshProductCompare.en-GB.json
@@ -10,7 +10,8 @@
             "empty": "No products have been added to compare yet.",
             "headline": "Compare products",
             "maximumCompareProducts": "Maximum number of compare products is 4",
-            "removeFromCompare": "Remove from compare"
+            "removeFromCompare": "Remove from compare",
+            "productsRemoved": "%count% unavailable product(s) have been removed from the comparison."
         },
         "offcanvas": {
             "compareNow": "Compare Now",

--- a/src/Resources/views/storefront/component/compare/compare-float.html.twig
+++ b/src/Resources/views/storefront/component/compare/compare-float.html.twig
@@ -1,9 +1,10 @@
 {% block frosh_product_compare_float_button_inner %}
-    {% set buttonClasses = buttonClasses ?? 'btn-primary' %}
+    {% set buttonClasses = buttonClasses ?? ('btn-' ~ (config('FroshProductCompare.config.floatingButtonStyle') ?? 'primary')) %}
     {% set floatingButtonClasses = floatingButtonClasses ?? 'compare-float-button' %}
     {% set badgeClasses = badgeClasses ?? 'bg-danger' %}
     {% set compareFloatOptions = {
-        maximumNumberCompareProductsText: "froshProductCompare.general.maximumCompareProducts"|trans|sw_sanitize
+        maximumNumberCompareProductsText: "froshProductCompare.general.maximumCompareProducts"|trans|sw_sanitize,
+        productsRemovedText: "froshProductCompare.general.productsRemoved"|trans|sw_sanitize
     } %}
 
     <div data-compare-float="true" data-compare-float-options="{{ compareFloatOptions|json_encode }}">

--- a/src/Resources/views/storefront/component/compare/content.html.twig
+++ b/src/Resources/views/storefront/component/compare/content.html.twig
@@ -1,5 +1,5 @@
 {% block frosh_product_compare_table_container %}
-    <div class="comparison-table">
+    <div class="comparison-table" data-valid-product-ids="{{ page.products.ids|json_encode }}">
         {% set products = page.products %}
         {% set hideAttributes = config('FroshProductCompare.config.hideAttributes') %}
 

--- a/src/Resources/views/storefront/component/compare/offcanvas-compare-list.html.twig
+++ b/src/Resources/views/storefront/component/compare/offcanvas-compare-list.html.twig
@@ -12,7 +12,7 @@
     {% block component_offcanvas_product_compare %}
         {% set isCompareProductsNotEmpty = (page.products|length > 0) %}
 
-        <div class="offcanvas-cart">
+        <div class="offcanvas-cart" data-valid-product-ids="{{ page.products.ids|json_encode }}">
 
             {% block component_offcanvas_product_compare_header %}
                 <div class="row align-items-center h4 offcanvas-cart-header">

--- a/src/Resources/views/storefront/component/product/card/compare-button.html.twig
+++ b/src/Resources/views/storefront/component/product/card/compare-button.html.twig
@@ -1,25 +1,29 @@
 {% block frosh_product_compare_add_to_compare_box %}
     {% set showIconOnly = config('FroshProductCompare.config.showIconOnly') %}
+    {% set compareButtonStyle = config('FroshProductCompare.config.compareButtonStyle') ?? 'primary' %}
+    {% set compareButtonSelectedStyle = config('FroshProductCompare.config.compareButtonSelectedStyle') ?? 'secondary' %}
     {# @var product \Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity #}
     <div class="compare-button d-grid">
         {% set addToCompareOptions = {
             productId: product.id,
             showIconOnly: showIconOnly,
             defaultText: "froshProductCompare.general.addToCompare"|trans|sw_sanitize,
-            addedText: "froshProductCompare.general.removeFromCompare"|trans|sw_sanitize
+            addedText: "froshProductCompare.general.removeFromCompare"|trans|sw_sanitize,
+            defaultButtonClass: 'btn-' ~ compareButtonStyle,
+            selectedButtonClass: 'btn-' ~ compareButtonSelectedStyle
         } %}
         {% block frosh_product_compare_add_to_compare_button %}
             {% if showIconOnly %}
                 <button data-add-to-compare-button="true"
                         data-add-to-compare-button-options="{{ addToCompareOptions|json_encode }}"
-                        class="btn btn-block btn-compare"
+                        class="btn btn-{{ compareButtonStyle }}"
                         title="{{ "froshProductCompare.general.addToCompare"|trans|striptags }}">
                     {% sw_icon 'bag-product' style { 'size': 'sm', 'color': 'primary' } %}
                 </button>
             {% else %}
                 <button data-add-to-compare-button="true"
                         data-add-to-compare-button-options="{{ addToCompareOptions|json_encode }}"
-                        class="btn btn-block btn-compare"
+                        class="btn btn-{{ compareButtonStyle }}"
                         title="{{ "froshProductCompare.general.addToCompare"|trans|striptags }}">
                     {{ "froshProductCompare.general.addToCompare"|trans|sw_sanitize }}
                 </button>

--- a/src/Resources/views/storefront/page/compare.html.twig
+++ b/src/Resources/views/storefront/page/compare.html.twig
@@ -18,7 +18,10 @@
 
         <div class="cms-page show-on-print">
             {% block frosh_product_compare_page_content_block %}
-                <div class="compare-product-container" data-compare-widget="true">
+                {% set compareWidgetOptions = {
+                    productsRemovedText: "froshProductCompare.general.productsRemoved"|trans|sw_sanitize
+                } %}
+                <div class="compare-product-container" data-compare-widget="true" data-compare-widget-options="{{ compareWidgetOptions|json_encode }}">
 
                     {% block frosh_product_compare_page_content_action %}
                         <div class="row no-gutters mt-3 pb-3 hide-on-print action-row d-print-none">


### PR DESCRIPTION
Adds plugin configuration to control the compare button and fixes the compare page to respect the closeout setting.

- config.xml: compare button configuration options
- CompareProductPageLoader: filter closeout/out-of-stock products from the compare result when core.listing.hideCloseoutProductsWhenOutOfStock is enabled
- storefront: CompareLocalStorageHelper.sync() prunes the localStorage compare list against valid product ids, used by the compare-float and compare-widget plugins
- snippets and compare templates updated accordingly
- .gitignore: ignore compiled assets under src/Resources/public/